### PR TITLE
Alias parser bugfix

### DIFF
--- a/lib/parsers/alias_parser.rb
+++ b/lib/parsers/alias_parser.rb
@@ -9,12 +9,13 @@ module KMExport
     data_output = IO.open(IO.sysopen(new_filename, "w"), "w")
 
     until input.eof?
-      line = JSON.parse(input.readline)
+      original_line = input.readline
+      line = JSON.parse(original_line)
       if line["_p2"]
-        alias_output.write(JSON.generate(line))
+        alias_output.write(original_line)
         alias_output.write("\n")
       else
-        data_output.write(JSON.generate(line))
+        data_output.write(original_line)
         data_output.write("\n")
       end
     end


### PR DESCRIPTION
The alias parser was deserializing the JSON then serializing it again just to copy the same line over to a different file. This PR makes it so the parser avoids writing the deserialized/serialized JSON and simply copies over the line exactly as it was read. I think this will help to avoid encoding issues that I've been running into, but it's just a guess. I don't see any reason why we would need to serialize the same line again since we already have the serialized line.